### PR TITLE
Removed the Mod Role ping being deleted in !pingmods

### DIFF
--- a/cogs/pingmods.py
+++ b/cogs/pingmods.py
@@ -60,8 +60,8 @@ class PingMods(commands.Cog, name="Ping Mods"):
             # Send embed
             await ctx.send(embed=embed)
 
-            # Create essentially a ghost ping to Mod role and delete almost instantly.
-            await ctx.send(modRole.mention, delete_after=0.1)
+            # Ping Moderators
+            await ctx.send(modRole.mention)
 
 
 def setup(bot):


### PR DESCRIPTION
As per the request of the Mod team for auditing.

Haven't been able to test locally in dev, but it's just deleting `delete_after=0.1` in `await ctx.send(modRole.mention, delete_after=0.1)`  on the send that creates the ping